### PR TITLE
Reset config functions and properties

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ parent="smn_machine_drivers"
 
 This plugin adds support for [Gandi](https://www.gandi.net/) cloud instances to the `docker-machine` command line tool.
 
-[![CircleCI](https://img.shields.io/circleci/project/gandi/docker-machine-gandi.svg)](https://circleci.com/gh/gandi/docker-machine-gandi/)
+<!-- [![CircleCI](https://img.shields.io/circleci/project/gandi/docker-machine-gandi.svg)](https://circleci.com/gh/gandi/docker-machine-gandi/) -->
 
 ## Installation
 
@@ -28,7 +28,10 @@ Grab your API key from the [Gandi admin](https://www.gandi.net/admin/api_key) an
 
 **Example for creating a new machine running default Ubuntu 14.04:**
 
-    docker-machine create --driver gandi --gandi-api-key=abc123 ubuntu-machine
+    docker-machine create --engine-storage-driver devicemapper \
+                          --driver gandi \
+                          --gandi-api-key=abc123 \
+                          ubuntu-machine
 
 Command line flags:
 


### PR DESCRIPTION
Tweak/reset/fix functions and properties related to IP, SSH and provisioning config.

Also adds the `--engine-storage-driver devicemapper` option to the code example in the Readme. Machine provisioning defaults to `aufs` on Ubuntu 14.04 with upstart[1], which isn't supported by the current default kernel version (3.12.x) and therefore fails to start the docker daemon.

[1] https://github.com/docker/machine/blob/5ee9dfdc94cb38e0dfdd8781d02d351baef86e02/libmachine/provision/ubuntu_upstart.go#L144-L146
